### PR TITLE
Don't open devtools at launch

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,8 +14,8 @@ app.on('ready', function() {
   // Load the main interface
   win.loadURL('file://' + __dirname + '/index.html');
 
-  // Open the DevTools. FIXME: Comment this out before release
-  win.webContents.openDevTools({'mode':'undocked'});
+  // Uncomment this line to open the DevTools upon launch. 
+  //win.webContents.openDevTools({'mode':'undocked'});
 
   win.on('closed', function() {
     // Dereference the window object so our app exits


### PR DESCRIPTION
I think it's time we stop doing this by default. We have end users using this tool now.