### PR TITLE
Update electron and electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/jackhumbert/dfu-programmer-app",
   "devDependencies": {
-    "electron-prebuilt": "^1.2.0",
-    "electron-builder": "^3.25.0"
+    "electron": "^1.4.10",
+    "electron-builder": "^8.6.0"
   },
   "build": {
     "app-bundle-id": "com.github.dfu-programmer-app",


### PR DESCRIPTION
This is especially important since the electron-prebuilt name will stop working starting next year.