### PR TITLE
Improve error detection [Test first]

### DIFF
--- a/app.js
+++ b/app.js
@@ -191,8 +191,8 @@ function resetChip(callback) {
   execFile(dfu_location, ['atmega32u4', 'reset'], function(error, stdout, stderr) {
     writeStatus(stdout);
     writeStatus(stderr);
-    if (stderr.indexOf("no device present") > -1) {
-      callback(false);
+	if (stderr.indexOf("Validating...  Success") == -1) {
+	  callback(false);
     } else {
       callback(true);
     }


### PR DESCRIPTION
Right now, the app shows a successful state when the flashing fails for any reason other than "no device present", such as "bootloader and code overlap". By instead checking for a successful response from dfu-programmer, we should be able to catch all error states.

Note: I haven't tested this myself, due to #10.