### PR TITLE
Make the program feel more native.

### DIFF
--- a/src/GearMenuWindow/style.css
+++ b/src/GearMenuWindow/style.css
@@ -1,5 +1,7 @@
 .dropdown-menu {
+    font: menu;
     display: block;
     margin: 0;
     min-width: 100%;
+    -webkit-user-select:none;
 }

--- a/src/MainWindow/style.css
+++ b/src/MainWindow/style.css
@@ -3,7 +3,7 @@
 }
 
 :focus {
-    outline: none;
+  outline: none;
 }
 
 *, *:before, *:after {
@@ -11,13 +11,20 @@
 }
 
 html, body {
-	height: 100%;
-	-webkit-app-region: drag;
+  height: 100%;
+  -webkit-app-region: drag;
+  font: message-box;
+  color: WindowText;
+  background-color: Window;
 }
 
 .button {
   border: 1px solid hsl(0, 0%, 83%);
   border-radius: 6px;
+}
+
+.btn, .button {
+  font: icon;
 }
 
 #file-path {
@@ -27,6 +34,8 @@ html, body {
   width: 503px;
   height: 24px;
   -webkit-app-region: no-drag;
+  -webkit-user-select: text;
+  text-overflow: ellipsis;
 }
 
 #load-file {
@@ -74,9 +83,10 @@ html, body {
 
 
 #status {
+  font: message-box;
   font-size: 12px;
-  background-color: #eee;
-  border: #ccc solid 1px;
+  background-color: #ddd;
+  border: ActiveBorder solid 1px;
   position: absolute;
   left: 14px;
   bottom: 62px;
@@ -84,9 +94,11 @@ html, body {
   width: 612px;
   border-radius: 2px;
   overflow-y: scroll;
-  font-family: monospace;
   white-space: pre-wrap;
   padding: 7px;
   -webkit-app-region: no-drag;
+}
+
+#status, #status b {
   -webkit-user-select: text;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ require('electron-debug')({showDevTools: false});
 const {app} = electron;
 const {BrowserWindow} = electron;
 const {ipcMain} = electron;
+const {Menu} = electron;
 const settings = require('electron-settings');
 
 let mainWin;  // Ensure that our mainWin isn't garbage collected
@@ -23,7 +24,7 @@ if(shouldQuit) {
 }
 
 app.on('ready', function() {
-  let mainWinOptions = {show: false, frame: true, resizable: false};
+  let mainWinOptions = {show: false, frame: true, resizable: false, icon: __dirname + 'build/icon.iconset/icon_128x128.png'};
   if (process.platform == 'win32') {
     mainWinOptions.width = 659;
     mainWinOptions.height = 510;
@@ -108,6 +109,45 @@ app.on('ready', function() {
     settingsCache.focusWindowOnHexChange = updatedSettings.focusWindowOnHexChange;
     settings.set('focusWindowOnHexChange', updatedSettings.focusWindowOnHexChange);
   });
+
+  // Setup the mac menu items
+  if (process.platform === 'darwin') {
+    const template = [
+      {
+        label: app.getName(),
+        submenu: [
+          {label: 'About '+app.getName(), click: function(menuItem, browserWindow, event) {mainWin.webContents.executeJavaScript("openAboutDialog()");}},
+          {role: 'separator'},
+          {role: 'services',submenu:[]},
+          {role: 'separator'},
+          {role: 'hide'},
+          {role: 'hideothers'},
+          {role: 'unhide'},
+          {role: 'separator'},
+          {role: 'quit'},
+        ]
+      }, {
+        label: 'Edit',
+        submenu: [
+          {role: 'copy'},
+          {role: 'selectall'}
+        ]
+      }, {
+        label: 'View',
+        submenu: [
+          {role: 'toggledevtools'}
+        ]
+      }, {
+        label: 'Window',
+        submenu: [
+          {role: 'minimize'},
+          {role: 'close'}
+        ]
+      }
+    ];
+    const menu = Menu.buildFromTemplate(template)
+    Menu.setApplicationMenu(menu);
+  }
 });
 
 // Quit when all windows are closed.


### PR DESCRIPTION
* Switch to system specific fonts and colors
* Add a menu for the mac to enable About, Copy, and Select All. (#26)
* Fix selection on the status box

Improvements were based on, or inspired by, these articles:

* https://blog.avocode.com/blog/4-must-know-tips-for-building-cross-platform-electron-apps
* https://www.sitepoint.com/css-system-styles/